### PR TITLE
Tune gcc-arm compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,11 @@ ARMGNU = arm-none-eabi
 
 COPS  = -mlittle-endian                               \
         -O2                                           \
-        -mfloat-abi=hard                              \
+        -march=armv7e-m+fpv5-d16                      \
+        -mtune=cortex-m7                              \
         -mthumb                                       \
-        -march=armv7e-m+fpv5                          \
+        -mfloat-abi=hard                              \
+        -ffast-math                                   \
         -Wa,-adhln=$(OBJ_DIR)/$(basename $(@F)).lst   \
         -g3                                           \
         -Wconversion                                  \
@@ -53,9 +55,11 @@ COPS  = -mlittle-endian                               \
 ifeq ($(LD), arm-none-eabi-ld)
   LOPS = -nostartfiles                          \
          -nostdlib                              \
-         -mfloat-abi=hard                       \
+         -march=armv7e-m+fpv5-d16               \
+         -mtune=cortex-m7                       \
          -mthumb                                \
-         -march=armv7e-m+fpv5                   \
+         -mfloat-abi=hard                       \
+         -ffast-math                            \
          -e Startup_Init                        \
          --print-memory-usage                   \
          --print-map                            \
@@ -66,9 +70,11 @@ ifeq ($(LD), arm-none-eabi-ld)
 else
   LOPS = -nostartfiles                          \
          -e Startup_Init                        \
-         -mfloat-abi=hard                       \
+         -march=armv7e-m+fpv5-d16               \
+         -mtune=cortex-m7                       \
          -mthumb                                \
-         -march=armv7e-m+fpv5                   \
+         -mfloat-abi=hard                       \
+         -ffast-math                            \
          -Wl,--print-memory-usage               \
          -Wl,--print-map                        \
          -Wl,-dT $(SRC_DIR)/Memory_Map.ld       \


### PR DESCRIPTION
Hi @Chalandi (Amine) I tuned the compiler flags in another project featuring more detailed integer and double-precision floating-point calculations. I like the proposed flags for GCC.

In particular, the `-d16` helps for the floating-point unit because that enables double-precision (8-byte) floating-point calculations in hardware on the metal of the chip's FPU.