### PR TITLE
Build handles C++ files

### DIFF
--- a/Code/shapes.cpp
+++ b/Code/shapes.cpp
@@ -1,0 +1,16 @@
+#include "Leds.h"
+
+class shape
+{
+public:
+  virtual ~shape() = default;
+
+protected:
+  shape() = default;
+};
+
+class circle : public shape
+{
+  circle() = default;
+  ~circle() override = default;
+};

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ VARIANT = $(EXECUTE_CODE_FROM_FLASH)
 
 AS      = arm-none-eabi-as
 CC      = arm-none-eabi-gcc
+CPP     = arm-none-eabi-g++
 LD      = arm-none-eabi-gcc
 OBJDUMP = arm-none-eabi-objdump
 OBJCOPY = arm-none-eabi-objcopy
@@ -233,7 +234,7 @@ $(OBJ_DIR)/%.o : %.s
 
 $(OBJ_DIR)/%.o : %.cpp
 	@-echo +++ compile: $(subst \,/,$<) to $(subst \,/,$@)
-	@$(CC) $(CPPOPS) -I$(INC_FILES) $< -o $(OBJ_DIR)/$(basename $(@F)).o 2> $(OBJ_DIR)/$(basename $(@F)).err
+	@$(CPP) $(CPPOPS) $(addprefix -I, $(INC_FILES)) -c $< -o $(OBJ_DIR)/$(basename $(@F)).o 2> $(OBJ_DIR)/$(basename $(@F)).err
 	@-$(PYTHON) CompilerErrorFormater.py $(OBJ_DIR)/$(basename $(@F)).err -COLOR
 
 $(OUTPUT_DIR)/$(PRJ_NAME).elf : $(FILES_O) $(LD_SCRIPT)


### PR DESCRIPTION
Hi Amine (@Chalandi) this build change handles C++ source files and linking them. The added file `shapes.cpp` can, of course, be deleted as it does nothing other than test the CPP pattern rule. There are a few options here. if you don't like the pattern rule, we can negotiate on it. It was, however, certainly ever so slightly incorrect previously due to the missing `ADDPREFIX` that was absent on the include paths. 